### PR TITLE
remove dependency on futures-await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,4 @@ license = "MIT"
 
 [dependencies]
 futures-cpupool = "0.1"
-futures-await = { git = 'https://github.com/alexcrichton/futures-await' }
-
-[dev-dependencies]
 futures = "0.1"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,5 @@ Buffered IO with futures on top of a threadpool for blocking IO. This crate is
 primarily useful for readers or writers that cannot return EWOULDBLOCK, but may
 block or sleep (i.e., file IO).
 
-This uses futures-await, which is built on top of an experimental,
-[nightly only](https://github.com/rust-lang/rust/pull/43076) feature and
-requires other nightly features.
+This uses the nightly only feature [`conservative_impl_trait`](https://doc.rust-lang.org/nightly/unstable-book/language-features/conservative-impl-trait.html)
+to make the types on non-allocating futures understable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,18 +3,13 @@
 //! This crate is most useful when readers or writers do not or cannot block, but do put threads to
 //! sleep. For example, files can always read or write, but their reads or writes are slow.
 //!
-//! This crate uses three nightly-only features: [`proc_macro`], [`conservative_impl_trait`], and
-//! [`generators`]. These requirements come from using [`futures-await`]. It is possible to write
-//! all code in this crate with explicit (non impl) futures as return types and to not use
-//! async/await, but the code would be much, much uglier.
+//! This crate uses the nightly-only feature [`conservative_impl_trait`] to eliminate box
+//! allocations around futures while still making the return types semi-readable.
 //!
-//! [`futures-await`]: https://github.com/alexcrichton/futures-await
-//! [`proc_macro`]: https://doc.rust-lang.org/nightly/unstable-book/language-features/proc-macro.html
 //! [`conservative_impl_trait`]: https://doc.rust-lang.org/nightly/unstable-book/language-features/conservative-impl-trait.html
-//! [`generators`]: https://doc.rust-lang.org/nightly/unstable-book/language-features/generators.html
-#![feature(proc_macro, conservative_impl_trait, generators)]
+#![feature(conservative_impl_trait)]
 
-extern crate futures_await as futures;
+extern crate futures;
 extern crate futures_cpupool;
 
 mod read;


### PR DESCRIPTION
This actually turned out to be much easier than I thought it would be,
and removing this dependency allows this crate to be publishable.