### PR TITLE
Add repository meta to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Travis Bischel <travis.bischel@gmail.com>"]
 description = "Buffered IO with futures on top of a threadpool for blocking IO"
 documentation = "https://docs.rs/futures-bufio"
+repository = "https://github.com/twmb/futures-bufio"
 readme = "README.md"
 keywords = ["futures", "future", "bufio", "io", "async"]
 categories = ["asynchronous", "filesystem"]


### PR DESCRIPTION
Hi there!


I saw your [post on the users discourse](https://users.rust-lang.org/t/design-review-for-futures-bufio/12727) asking for an API review. I haven't had a chance to dig in to the code yet but noticed you're missing a `repository` tag in the `Cargo.toml`. Just adding that in so it's easier to get here from `crates.io`.

cc: @twmb 