### PR TITLE
0.2.0: remove Box<[u8]> requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-bufio"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Travis Bischel <travis.bischel@gmail.com>"]
 description = "Buffered IO with futures on top of a threadpool for blocking IO"
 documentation = "https://docs.rs/futures-bufio"


### PR DESCRIPTION
Really, this only cares about being able to dereference into [u8].
Making write_all and try_read_full generic simplifies usage and expands
use cases.