### PR TITLE
Destructure instead of mem::swap on pool

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,5 @@
-/// A common error string that we use whenever expecting a `CpuPool`.
-pub(crate) const EXP_POOL: &str = "pool is always put back when returning from functions that \
-                                   take it";
+/// A common error string that we use whenever expecting a `read()` call on a `&[u8]`.
+pub(crate) const U8READ: &str = "&[u8] reads never error";
 
 /// Copies as many `T` as possible from `src` into `dst`, returning the number of `T` copied. This
 /// function is short form for `dst.copy_from_slice(src)`, but accounts for if their lengths are
@@ -24,9 +23,9 @@ pub(crate) fn copy(dst: &mut [u8], src: &[u8]) -> usize {
     let src_len = src.len();
     let dst_len = dst.len();
     if dst_len >= src_len {
-        src.read(&mut dst[..src_len]).unwrap()
+        src.read(&mut dst[..src_len]).expect(U8READ)
     } else {
-        (&src[..dst_len]).read(dst).unwrap()
+        (&src[..dst_len]).read(dst).expect(U8READ)
     }
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,9 +5,7 @@ use futures_cpupool::CpuPool;
 use std::ops::DerefMut;
 
 use std::io::{self, Read};
-use std::mem;
-
-use common::EXP_POOL;
+use common::U8READ;
 
 /// Adds buffering to any reader, similar to the [standard `BufReader`], but performs non-buffer
 /// reads in a thread pool.
@@ -47,11 +45,15 @@ use common::EXP_POOL;
 /// # }
 /// ```
 pub struct BufReader<R> {
+    reader: BufReaderInner<R>,
+    pool: CpuPool,
+}
+
+struct BufReaderInner<R> {
     inner: R,
     buf: Box<[u8]>,
     pos: usize,
     cap: usize,
-    pool: Option<CpuPool>,
 }
 
 /// Wraps `R` with the original buffer being read into and the number of bytes read.
@@ -104,11 +106,13 @@ impl<R: Read + Send + 'static> BufReader<R> {
     pub fn with_pool_and_buf(pool: CpuPool, buf: Box<[u8]>, inner: R) -> BufReader<R> {
         let cap = buf.len();
         BufReader {
-            inner: inner,
-            buf: buf,
-            pos: cap,
-            cap: cap,
-            pool: Some(pool),
+            reader: BufReaderInner {
+                inner,
+                buf: buf,
+                pos: cap,
+                cap: cap,
+            },
+            pool: pool,
         }
     }
 
@@ -117,7 +121,7 @@ impl<R: Read + Send + 'static> BufReader<R> {
     /// It is likely invalid to read directly from the underlying reader and then use the `BufReader`
     /// again.
     pub fn get_ref(&self) -> &R {
-        &self.inner
+        &self.reader.inner
     }
 
     /// Gets a mutable reference to the underlying reader.
@@ -125,7 +129,7 @@ impl<R: Read + Send + 'static> BufReader<R> {
     /// It is likely invalid to read directly from the underlying reader and then use the `BufReader`
     /// again.
     pub fn get_mut(&mut self) -> &R {
-        &mut self.inner
+        &mut self.reader.inner
     }
 
     /// Sets the `BufReader`s internal buffer position to `pos`.
@@ -182,7 +186,7 @@ impl<R: Read + Send + 'static> BufReader<R> {
     /// # }
     /// ```
     pub unsafe fn set_pos(&mut self, pos: usize) {
-        self.pos = pos;
+        self.reader.pos = pos;
     }
 
     /// Returns the internal components of a `BufReader`, allowing reuse. This
@@ -207,12 +211,8 @@ impl<R: Read + Send + 'static> BufReader<R> {
     /// assert_eq!(buf.len(), 4<<10);
     /// # }
     /// ```
-    pub unsafe fn components(mut self) -> (R, Box<[u8]>, CpuPool) {
-        let r = mem::replace(&mut self.inner, mem::uninitialized());
-        let buf = mem::replace(&mut self.buf, mem::uninitialized());
-        let mut pool = mem::replace(&mut self.pool, mem::uninitialized());
-        let pool = pool.take().expect(EXP_POOL);
-        mem::forget(self);
+    pub unsafe fn components(self) -> (R, Box<[u8]>, CpuPool) {
+        let BufReader { reader: BufReaderInner { inner: r, buf, .. }, pool, .. } = self;
         (r, buf, pool)
     }
 
@@ -258,16 +258,15 @@ impl<R: Read + Send + 'static> BufReader<R> {
     where
         B: DerefMut<Target = [u8]> + Send + 'static,
     {
-        const U8READ: &str = "&[u8] reads never error";
         let mut rem = buf.len();
         let mut at = 0;
 
-        if self.pos != self.cap {
-            at = (&self.buf[self.pos..self.cap]).read(&mut buf).expect(
+        if self.reader.pos != self.reader.cap {
+            at = (&self.reader.buf[self.reader.pos..self.reader.cap]).read(&mut buf).expect(
                 U8READ,
             );
             rem -= at;
-            self.pos += at;
+            self.reader.pos += at;
 
             if rem == 0 {
                 return Either::A(ok::<OkRead<Self, B>, ErrRead<Self, B>>((self, buf, at)));
@@ -275,48 +274,46 @@ impl<R: Read + Send + 'static> BufReader<R> {
         }
         // self.pos == self.cap
 
-        let pool = self.pool.take().expect(EXP_POOL);
-
-        let block = if self.cap > 0 {
-            rem - rem % self.cap
+        let block = if self.reader.cap > 0 {
+            rem - rem % self.reader.cap
         } else {
             rem
         };
 
+        let BufReader { mut reader, pool } = self;
+
         let fut = pool.spawn_fn(move || {
             if block > 0 {
-                let (block_read, err) = try_read_full(&mut self.inner, &mut buf[at..at + block]);
+                let (block_read, err) = try_read_full(&mut reader.inner, &mut buf[at..at + block]);
                 if let Some(e) = err {
-                    return Err((self, buf, e));
+                    return Err((reader, buf, e));
                 }
 
                 at += block_read;
                 rem -= block_read;
                 if rem == 0 {
-                    return Ok((self, buf, at));
+                    return Ok((reader, buf, at));
                 }
             }
 
-            let (buf_read, err) = try_read_full(&mut self.inner, &mut self.buf);
+            let (buf_read, err) = try_read_full(&mut reader.inner, &mut reader.buf);
             match err {
-                Some(e) => Err((self, buf, e)),
+                Some(e) => Err((reader, buf, e)),
                 None => {
-                    self.cap = buf_read;
-                    self.pos = (&self.buf[..self.cap]).read(&mut buf[at..]).expect(U8READ);
-                    at += self.pos;
-                    Ok((self, buf, at))
+                    reader.cap = buf_read;
+                    reader.pos = (&reader.buf[..reader.cap]).read(&mut buf[at..]).expect(U8READ);
+                    at += reader.pos;
+                    Ok((reader, buf, at))
                 }
             }
         });
 
         Either::B(fut.then(|res| match res {
-            Ok(mut x) => {
-                x.0.pool = Some(pool);
-                Ok(x)
+            Ok((reader, buf, at)) => {
+                Ok((BufReader { reader, pool }, buf, at))
             }
-            Err(mut x) => {
-                x.0.pool = Some(pool);
-                Err(x)
+            Err((reader, buf, at)) => {
+                Err((BufReader { reader, pool }, buf, at))
             }
         }))
     }
@@ -366,7 +363,7 @@ fn test_read() {
             "foo does not exist?",
         ),
     );
-    assert_eq!(f.pos, 10);
+    assert_eq!(f.reader.pos, 10);
 
     // disk read, no blocks
     let (f, buf, n) = f.try_read_full(vec![0; 5]).wait().unwrap_or_else(
@@ -376,9 +373,9 @@ fn test_read() {
     );
     assert_eq!(n, 5);
     assert_eq!(&*buf, b"Strap");
-    assert_eq!(f.pos, 5);
-    assert_eq!(f.cap, 10);
-    assert_eq!(&*f.buf, b"Strapped d");
+    assert_eq!(f.reader.pos, 5);
+    assert_eq!(f.reader.cap, 10);
+    assert_eq!(&*f.reader.buf, b"Strapped d");
 
     // mem read only
     let (f, buf, n) = f.try_read_full(vec![0; 2]).wait().unwrap_or_else(
@@ -388,9 +385,9 @@ fn test_read() {
     );
     assert_eq!(n, 2);
     assert_eq!(&*buf, b"pe");
-    assert_eq!(f.pos, 7);
-    assert_eq!(f.cap, 10);
-    assert_eq!(&*f.buf, b"Strapped d");
+    assert_eq!(f.reader.pos, 7);
+    assert_eq!(f.reader.cap, 10);
+    assert_eq!(&*f.reader.buf, b"Strapped d");
 
     // mem (3) + disk blocks (20) + more mem (2)
     let (f, buf, n) = f.try_read_full(vec![0; 25]).wait().unwrap_or_else(
@@ -400,9 +397,9 @@ fn test_read() {
     );
     assert_eq!(n, 25);
     assert_eq!(&*buf, b"d down to my bed, feet co");
-    assert_eq!(f.pos, 2);
-    assert_eq!(f.cap, 10);
-    assert_eq!(&*f.buf, b"cold, eyes");
+    assert_eq!(f.reader.pos, 2);
+    assert_eq!(f.reader.cap, 10);
+    assert_eq!(&*f.reader.buf, b"cold, eyes");
 
     // mem (8) + disk block (10)
     let (f, buf, n) = f.try_read_full(vec![0; 18]).wait().unwrap_or_else(
@@ -412,9 +409,9 @@ fn test_read() {
     );
     assert_eq!(n, 18);
     assert_eq!(&*buf, b"ld, eyes red. I'm ");
-    assert_eq!(f.pos, 10);
-    assert_eq!(f.cap, 10);
-    assert_eq!(&*f.buf, b"cold, eyes"); // non-reset buf
+    assert_eq!(f.reader.pos, 10);
+    assert_eq!(f.reader.cap, 10);
+    assert_eq!(&*f.reader.buf, b"cold, eyes"); // non-reset buf
 
     // disk block (10)
     let (f, buf, n) = f.try_read_full(vec![0; 10]).wait().unwrap_or_else(
@@ -424,9 +421,9 @@ fn test_read() {
     );
     assert_eq!(n, 10);
     assert_eq!(&*buf, b"out of my ");
-    assert_eq!(f.pos, 10);
-    assert_eq!(f.cap, 10);
-    assert_eq!(&*f.buf, b"cold, eyes");
+    assert_eq!(f.reader.pos, 10);
+    assert_eq!(f.reader.cap, 10);
+    assert_eq!(&*f.reader.buf, b"cold, eyes");
 
     // disk block (20) + mem (9) (over-read by one byte)
     let (f, buf, n) = f.try_read_full(vec![0; 29]).wait().unwrap_or_else(
@@ -436,9 +433,9 @@ fn test_read() {
     );
     assert_eq!(n, 28);
     assert_eq!(&*buf, b"head. Am I alive? Am I dead?\0");
-    assert_eq!(f.pos, 8);
-    assert_eq!(f.cap, 8);
-    assert_eq!(&*f.buf, b" I dead?es");
+    assert_eq!(f.reader.pos, 8);
+    assert_eq!(f.reader.cap, 8);
+    assert_eq!(&*f.reader.buf, b" I dead?es");
 
     let (f, buf, n) = f.try_read_full(vec![0; 2]).wait().unwrap_or_else(
         |(_, _, e)| {
@@ -447,9 +444,9 @@ fn test_read() {
     );
     assert_eq!(n, 0);
     assert_eq!(&*buf, b"\0\0");
-    assert_eq!(f.pos, 0);
-    assert_eq!(f.cap, 0);
-    assert_eq!(&*f.buf, b" I dead?es");
+    assert_eq!(f.reader.pos, 0);
+    assert_eq!(f.reader.cap, 0);
+    assert_eq!(&*f.reader.buf, b" I dead?es");
 
     fs::remove_file("bar.txt").expect("expected file to be removed");
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -3,7 +3,6 @@ use futures::future::{Either, ok};
 use futures_cpupool::CpuPool;
 
 use std::io::{self, Write};
-use std::mem;
 use std::ops::Deref;
 
 use common::*;
@@ -52,11 +51,15 @@ use common::*;
 /// # }
 /// ```
 pub struct BufWriter<W> {
+    writer: BufWriterInner<W>,
+    pool: CpuPool,
+}
+
+struct BufWriterInner<W> {
     inner: W,
     buf: Box<[u8]>,
     pos: usize,
     w_start: usize,
-    pool: Option<CpuPool>,
 }
 
 /// Wraps `W` with the original buffer being written.
@@ -108,11 +111,13 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// ```
     pub fn with_pool_and_buf(pool: CpuPool, buf: Box<[u8]>, inner: W) -> BufWriter<W> {
         BufWriter {
-            inner: inner,
-            buf: buf,
-            pos: 0,
-            w_start: 0,
-            pool: Some(pool),
+            writer: BufWriterInner {
+                inner: inner,
+                buf: buf,
+                pos: 0,
+                w_start: 0,
+            },
+            pool: pool,
         }
     }
 
@@ -121,7 +126,7 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// It is likely invalid to read directly from the underlying writer and then use the
     /// `BufWriter` again.
     pub fn get_ref(&self) -> &W {
-        &self.inner
+        &self.writer.inner
     }
 
     /// Gets a mutable reference to the underlying writer.
@@ -129,7 +134,7 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// It is likely invalid to read directly from the underlying writer and then use the
     /// `BufWriter` again.
     pub fn get_mut(&mut self) -> &W {
-        &mut self.inner
+        &mut self.writer.inner
     }
 
     /// Returns the internal components of a `BufWriter`, allowing reuse. This
@@ -154,12 +159,8 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// assert_eq!(buf.len(), 4<<10);
     /// # }
     /// ```
-    pub unsafe fn components(mut self) -> (W, Box<[u8]>, CpuPool) {
-        let w = mem::replace(&mut self.inner, mem::uninitialized());
-        let buf = mem::replace(&mut self.buf, mem::uninitialized());
-        let mut pool = mem::replace(&mut self.pool, mem::uninitialized());
-        let pool = pool.take().expect(EXP_POOL);
-        mem::forget(self);
+    pub unsafe fn components(self) -> (W, Box<[u8]>, CpuPool) {
+        let BufWriter { writer: BufWriterInner { inner: w, buf, .. }, pool, .. } = self;
         (w, buf, pool)
     }
 
@@ -214,7 +215,7 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// # }
     /// ```
     pub unsafe fn set_pos(&mut self, pos: usize) {
-        self.pos = pos;
+        self.writer.pos = pos;
     }
 
     /// Writes all of `buf` to the `BufWriter`, returning the buffer for potential reuse and any
@@ -256,57 +257,56 @@ impl<W: Write + Send + 'static> BufWriter<W> {
         let mut at = 0;
         let mut write_buf = false;
 
-        if self.pos == 0 {
-            if buf.len() < self.buf.len() {
-                self.pos = copy(&mut self.buf, &*buf);
+        if self.writer.pos == 0 {
+            if buf.len() < self.writer.buf.len() {
+                self.writer.pos = copy(&mut self.writer.buf, &*buf);
                 return Either::A(ok::<OkWrite<Self, B>, ErrWrite<Self, B>>((self, buf)));
             }
         } else {
-            at = copy(&mut self.buf[self.pos..], &*buf);
-            self.pos += at;
+            at = copy(&mut self.writer.buf[self.writer.pos..], &*buf);
+            self.writer.pos += at;
             rem -= at;
 
-            if self.pos != self.buf.len() {
+            if self.writer.pos != self.writer.buf.len() {
                 return Either::A(ok::<OkWrite<Self, B>, ErrWrite<Self, B>>((self, buf)));
             }
             write_buf = true;
         }
 
-        let pool = self.pool.take().expect(EXP_POOL);
+        let BufWriter { mut writer, pool } = self;
+
         let fut = pool.spawn_fn(move || {
             if write_buf {
-                if let Err(e) = self.inner.write_all(&self.buf[self.w_start..]) {
-                    return Err((self, buf, e));
+                if let Err(e) = writer.inner.write_all(&writer.buf[writer.w_start..]) {
+                    return Err((writer, buf, e));
                 }
-                self.w_start = 0;
+                writer.w_start = 0;
             }
 
-            if rem >= self.buf.len() {
+            if rem >= writer.buf.len() {
                 let n_write = rem -
-                    if self.buf.len() != 0 {
-                        rem % self.buf.len()
+                    if writer.buf.len() != 0 {
+                        rem % writer.buf.len()
                     } else {
                         0
                     };
-                if let Err(e) = self.inner.write_all(&buf[at..at + n_write]) {
-                    return Err((self, buf, e));
+                if let Err(e) = writer.inner.write_all(&buf[at..at + n_write]) {
+                    return Err((writer, buf, e));
                 }
                 at += n_write;
                 rem -= n_write;
             }
 
-            self.pos = copy(&mut self.buf, &buf[at..]);
-            Ok((self, buf))
+            writer.pos = copy(&mut writer.buf, &buf[at..]);
+            Ok((writer, buf))
         });
 
         Either::B(fut.then(|res| match res {
-            Ok(mut x) => {
-                x.0.pool = Some(pool);
-                Ok(x)
+            Ok((writer, buf)) => {
+                Ok((BufWriter { writer, pool }, buf))
             }
-            Err(mut x) => {
-                x.0.pool = Some(pool);
-                Err(x)
+            Err((writer, buf, e)) => {
+                Err((BufWriter { writer, pool }, buf, e))
             }
         }))
     }
@@ -320,28 +320,27 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// ```ignore
     /// let future = writer.flush_buf();
     /// ```
-    pub fn flush_buf(mut self) -> impl Future<Item = Self, Error = (Self, io::Error)> {
-        if self.w_start == self.pos {
+    pub fn flush_buf(self) -> impl Future<Item = Self, Error = (Self, io::Error)> {
+        if self.writer.w_start == self.writer.pos {
             return Either::A(ok::<Self, (Self, io::Error)>(self));
         }
 
-        let pool = self.pool.take().expect(EXP_POOL);
+        let BufWriter { mut writer, pool } = self;
+
         let fut = pool.spawn_fn(move || {
-            if let Err(e) = self.inner.write_all(&self.buf[self.w_start..self.pos]) {
-                return Err((self, e));
+            if let Err(e) = writer.inner.write_all(&writer.buf[writer.w_start..writer.pos]) {
+                return Err((writer, e));
             }
-            self.w_start = self.pos;
-            Ok(self)
+            writer.w_start = writer.pos;
+            Ok(writer)
         });
 
         Either::B(fut.then(|res| match res {
-            Ok(mut me) => {
-                me.pool = Some(pool);
-                Ok(me)
+            Ok(writer) => {
+                Ok(BufWriter { writer, pool })
             }
-            Err(mut x) => {
-                x.0.pool = Some(pool);
-                Err(x)
+            Err((writer, e)) => {
+                Err((BufWriter { writer, pool }, e))
             }
         }))
     }
@@ -354,23 +353,21 @@ impl<W: Write + Send + 'static> BufWriter<W> {
     /// ```ignore
     /// let future = writer.flush_inner();
     /// ```
-    pub fn flush_inner(mut self) -> impl Future<Item = Self, Error = (Self, io::Error)> {
-        let pool = self.pool.take().expect(EXP_POOL);
+    pub fn flush_inner(self) -> impl Future<Item = Self, Error = (Self, io::Error)> {
+        let BufWriter { mut writer, pool } = self;
         let fut = pool.spawn_fn(move || {
-            if let Err(e) = self.inner.flush() {
-                return Err((self, e));
+            if let Err(e) = writer.inner.flush() {
+                return Err((writer, e));
             }
-            Ok(self)
+            Ok(writer)
         });
 
         fut.then(|res| match res {
-            Ok(mut me) => {
-                me.pool = Some(pool);
-                Ok(me)
+            Ok(writer) => {
+                Ok(BufWriter { writer, pool })
             }
-            Err(mut x) => {
-                x.0.pool = Some(pool);
-                Err(x)
+            Err((writer, e)) => {
+                Err((BufWriter { writer, pool }, e))
             }
         })
     }
@@ -407,23 +404,23 @@ fn test_write() {
             panic!("unable to write to file: {}", e)
         },
     );
-    assert_eq!(f.pos, 5);
-    assert_eq!(f.w_start, 0);
+    assert_eq!(f.writer.pos, 5);
+    assert_eq!(f.writer.w_start, 0);
     assert_eq!(&*buf, b"hello");
     assert_foo("");
 
     let f = f.flush_buf().wait().unwrap_or_else(|(_, e)| {
         panic!("unable to flush buf: {}", e)
     });
-    assert_eq!(f.pos, 5);
-    assert_eq!(f.w_start, 5);
+    assert_eq!(f.writer.pos, 5);
+    assert_eq!(f.writer.w_start, 5);
     assert_foo("hello");
 
     let f = f.flush_inner().wait().unwrap_or_else(|(_, e)| {
         panic!("unable to flush file: {}", e)
     });
-    assert_eq!(f.pos, 5);
-    assert_eq!(f.w_start, 5);
+    assert_eq!(f.writer.pos, 5);
+    assert_eq!(f.writer.w_start, 5);
     assert_foo("hello");
 
     // memory (2) with w_start at 5
@@ -432,16 +429,16 @@ fn test_write() {
             panic!("unable to write to file: {}", e)
         },
     );
-    assert_eq!(f.pos, 7);
-    assert_eq!(f.w_start, 5);
+    assert_eq!(f.writer.pos, 7);
+    assert_eq!(f.writer.w_start, 5);
     assert_eq!(&*buf, b"tw");
     assert_foo("hello");
 
     let f = f.flush_buf().wait().unwrap_or_else(|(_, e)| {
         panic!("unable to flush buf: {}", e)
     });
-    assert_eq!(f.pos, 7);
-    assert_eq!(f.w_start, 7);
+    assert_eq!(f.writer.pos, 7);
+    assert_eq!(f.writer.w_start, 7);
     assert_foo("hellotw");
 
     // memory (7)
@@ -450,8 +447,8 @@ fn test_write() {
             panic!("unable to write to file: {}", e)
         },
     );
-    assert_eq!(f.pos, 4);
-    assert_eq!(f.w_start, 0);
+    assert_eq!(f.writer.pos, 4);
+    assert_eq!(f.writer.w_start, 0);
     assert_eq!(&*buf, b"goodbye");
     assert_foo("hellotwgoo");
 
@@ -459,8 +456,8 @@ fn test_write() {
     let (f, buf) = f.write_all(b"more++andthenten".to_vec())
         .wait()
         .unwrap_or_else(|(_, _, e)| panic!("unable to write to file: {}", e));
-    assert_eq!(f.pos, 0);
-    assert_eq!(f.w_start, 0);
+    assert_eq!(f.writer.pos, 0);
+    assert_eq!(f.writer.w_start, 0);
     assert_eq!(&*buf, b"more++andthenten");
     assert_foo("hellotwgoodbyemore++andthenten");
 
@@ -470,8 +467,8 @@ fn test_write() {
             panic!("unable to write to file: {}", e)
         },
     );
-    assert_eq!(f.pos, 0);
-    assert_eq!(f.w_start, 0);
+    assert_eq!(f.writer.pos, 0);
+    assert_eq!(f.writer.w_start, 0);
     assert_eq!(&*buf, b"andtenmore");
     assert_foo("hellotwgoodbyemore++andthentenandtenmore");
 
@@ -479,16 +476,16 @@ fn test_write() {
     let (f, buf) = f.write_all(b"this is rly old".to_vec())
         .wait()
         .unwrap_or_else(|(_, _, e)| panic!("unable to write to file: {}", e));
-    assert_eq!(f.pos, 5);
-    assert_eq!(f.w_start, 0);
+    assert_eq!(f.writer.pos, 5);
+    assert_eq!(f.writer.w_start, 0);
     assert_eq!(&*buf, b"this is rly old");
     assert_foo("hellotwgoodbyemore++andthentenandtenmorethis is rl");
 
     let f = f.flush_buf().wait().unwrap_or_else(|(_, e)| {
         panic!("unable to flush buf: {}", e)
     });
-    assert_eq!(f.pos, 5);
-    assert_eq!(f.w_start, 5);
+    assert_eq!(f.writer.pos, 5);
+    assert_eq!(f.writer.w_start, 5);
     assert_foo("hellotwgoodbyemore++andthentenandtenmorethis is rly old");
 
     fs::remove_file("foo.txt").expect("expected file to be removed");


### PR DESCRIPTION
This is a change you may or may not be on-board with, but I thought I'd open up a PR and see what you think.

While poking through the code I thought it was a bit of a shame that you had to use `Option<CpuPool>` to swap with `mem::replace` in order to stop Rust complaining about using the borrowed pool within the closure you pass to it (assuming that's actually the reason).

This is a possible workaround that destructures the reader and writer and recomposes it on the other end of the future. It's possibly more noise than the current approach, but I think it captures the intent a bit better.

I also bundled in an unrelated change to the `components` methods. Unless I've missed something you really shouldn't need to manually uninitialise the memory at `self` when decomposing into raw parts.